### PR TITLE
Fix serial mirroring and pane borders

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -29,6 +29,8 @@
 - [x] Start with a single pane showing the shell prompt
 - [ ] Remove demo task output loop
 - [ ] Persist command input when panes are redrawn
-- [ ] Fix pane borders to use double-width white lines and show prompt in active pane
+- [x] Fix pane borders to use double-width white lines and show prompt in active pane
 - [ ] Add unit test for shell history navigation
 - [ ] Add unit test verifying console text persists after initialization
+- [ ] Add unit test ensuring VGA and serial outputs remain in sync
+- [ ] Document pane command usage and serial console setup

--- a/src/kernel/console/cmd.c
+++ b/src/kernel/console/cmd.c
@@ -11,10 +11,12 @@ static void show_help(void) {
     console_write("  clear - Clear the screen\n");
     console_write("  info  - Display hardware information\n");
     console_write("  gui   - Enter pane mode\n");
-    console_write("  exit-gui - Leave pane mode\n");
-    console_write("  wider  - Increase pane columns\n");
-    console_write("  taller - Increase pane rows\n");
-    console_write("  left/right/up/down - Move between panes\n");
+    if (pane_is_active()) {
+        console_write("  exit-gui - Leave pane mode\n");
+        console_write("  wider  - Increase pane columns\n");
+        console_write("  taller - Increase pane rows\n");
+        console_write("  left/right/up/down - Move between panes\n");
+    }
     console_write("  restart - Reboot the system\n");
     console_write("  shutdown - Power off the system\n");
     console_write("  exit  - Halt the system\n");

--- a/src/kernel/console/console.c
+++ b/src/kernel/console/console.c
@@ -63,12 +63,9 @@ void console_clear(void) {
 }
 
 void console_putc(char c) {
-    /* Only mirror printable ASCII to the serial port to keep the
-       host terminal clean when drawing GUI lines. */
-    if ((unsigned char)c >= 0x20 && (unsigned char)c < 0x7F)
-        serial_putc(c);
-    else if (c == '\n' || c == '\b' || c == '\t')
-        serial_putc(c);
+    /* Mirror all output to the serial console so QEMU always
+       shows the same text as the VGA display. */
+    serial_putc(c);
     if (c == '\n') {
         cursor_x = 0;
         if (++cursor_y >= VGA_ROWS)

--- a/src/kernel/hmi/pane.c
+++ b/src/kernel/hmi/pane.c
@@ -10,10 +10,10 @@
 
 static int pane_enabled = 0;
 
-/* Box drawing characters from code page 437 - single line style */
-#define LINE_VERT  ((char)0xB3)
-#define LINE_HORZ  ((char)0xC4)
-#define LINE_CROSS ((char)0xC5)
+/* Box drawing characters from code page 437 - double line style */
+#define LINE_VERT  ((char)0xBA)
+#define LINE_HORZ  ((char)0xCD)
+#define LINE_CROSS ((char)0xCE)
 
 static unsigned int grid_w = 1;
 static unsigned int grid_h = 1;


### PR DESCRIPTION
## Summary
- ensure console output is mirrored to serial
- draw pane borders using CP437 double lines
- hide pane commands from `help` when GUI mode disabled
- mark plan item complete and add follow-ups

## Testing
- `gcc -I src -DINVENTORY_TEST tests/inventory_test.c src/kernel/inventory/inventory.c src/kernel/inventory/pci_classes.c -o tests/inventory_test && ./tests/inventory_test; echo "exit=$?"`
- `gcc -I src -DACPI_TEST tests/acpi_test.c src/kernel/acpi/acpi.c -o tests/acpi_test && ./tests/acpi_test; echo "exit=$?"`

------
https://chatgpt.com/codex/tasks/task_e_6849ce9531ac8320bba7753f81a84a3b