### PR TITLE
Fix ACPI discovery and add debug output

### DIFF
--- a/Documentation/architecture/kernel/power_management/acpi_parser_stub.txt
+++ b/Documentation/architecture/kernel/power_management/acpi_parser_stub.txt
@@ -10,3 +10,8 @@ Table provides the PM1 control registers used for shutdown.  Should any
 required table be missing the routine falls back to defaults compatible
 with QEMU.  The `acpi_get_fadt()` accessor returns the parsed FADT while
 `acpi_get_table()` allows lookups by signature.
+
+The bootloader now maps the first gigabyte of physical memory so ACPI
+tables located above the 2 MiB mark are accessible early in kernel
+startup.  When a table is discovered the parser prints its address and
+key fields for debugging over the serial console.

--- a/PLAN.md
+++ b/PLAN.md
@@ -23,6 +23,7 @@
 - [ ] Add unit test verifying multiple GPU enumeration
 - [ ] Add unit test for ACPI table lookup
 - [ ] Document ACPI table discovery improvements
+- [ ] Validate ACPI table checksums for integrity
 - [ ] Map vendor IDs to names in info output
 - [ ] Document dynamic pane manager and key bindings
 - [ ] Start with a single pane showing the shell prompt

--- a/src/boot/bootloader.asm
+++ b/src/boot/bootloader.asm
@@ -45,7 +45,7 @@ protected_mode:
     mov ss, ax
     mov esp, 0x7C00
 
-    ; Build identity mapped paging structures for first 2 MiB
+    ; Build identity mapped paging structures for first 1 GiB
     mov eax, pdpt
     or eax, 0x03
     mov [pml4], eax
@@ -54,8 +54,16 @@ protected_mode:
     or eax, 0x03
     mov [pdpt], eax
     mov dword [pdpt+4], 0
-    mov dword [pd], 0x00000083
-    mov dword [pd+4], 0
+    xor ecx, ecx
+setup_pd:
+    mov eax, ecx
+    shl eax, 21
+    or eax, 0x83
+    mov [pd + ecx*8], eax
+    mov dword [pd + ecx*8 + 4], 0
+    inc ecx
+    cmp ecx, 512
+    jne setup_pd
 
     ; Load paging structures
     mov eax, pml4

--- a/src/kernel/acpi/acpi.c
+++ b/src/kernel/acpi/acpi.c
@@ -4,6 +4,9 @@
 #include "../console/console.h"
 #else
 static void console_write(const char *s) { (void)s; }
+static void console_write_hex32(uint32_t v) { (void)v; }
+static void console_write_hex16(uint16_t v) { (void)v; }
+static void console_putc(char c) { (void)c; }
 /* Test harness provides the BIOS memory region to scan */
 extern unsigned char *acpi_test_mem_start;
 extern unsigned int acpi_test_mem_size;
@@ -84,6 +87,9 @@ void acpi_init(void) {
 #endif
 
     if (rsdp) {
+        console_write("RSDP found at 0x");
+        console_write_hex32((uint32_t)(uintptr_t)rsdp);
+        console_putc('\n');
         int use_xsdt = (rsdp->revision >= 2 && rsdp->xsdt_address);
         struct acpi_sdt_header *sdt = NULL;
 #ifdef ACPI_TEST
@@ -97,6 +103,11 @@ void acpi_init(void) {
         else if (!use_xsdt && rsdp->rsdt_address < 0x200000)
             sdt = (struct acpi_sdt_header *)(uintptr_t)rsdp->rsdt_address;
 #endif
+        if (sdt) {
+            console_write(use_xsdt ? "XSDT at 0x" : "RSDT at 0x");
+            console_write_hex32((uint32_t)(uintptr_t)sdt);
+            console_putc('\n');
+        }
         if (sdt && ((sdt->signature[0]=='R' && sdt->signature[1]=='S' && sdt->signature[2]=='D' && sdt->signature[3]=='T') ||
                     (sdt->signature[0]=='X' && sdt->signature[1]=='S' && sdt->signature[2]=='D' && sdt->signature[3]=='T'))) {
             acpi_table_count = 0;
@@ -127,6 +138,13 @@ void acpi_init(void) {
                     fadt_data.slp_typa = 0;
                     fadt_data.slp_typb = 0;
                     fadt_table = &fadt_data;
+                    console_write("FADT at 0x");
+                    console_write_hex32((uint32_t)addr);
+                    console_write(" PM1a=");
+                    console_write_hex16(fadt_data.pm1a_cnt_blk);
+                    console_write(" PM1b=");
+                    console_write_hex16(fadt_data.pm1b_cnt_blk);
+                    console_putc('\n');
                 }
             }
             console_write("ACPI tables parsed\n");

--- a/src/kernel/console/console.c
+++ b/src/kernel/console/console.c
@@ -113,6 +113,16 @@ void console_write_hex16(uint16_t value) {
     console_write_hex8(value & 0xFF);
 }
 
+void console_write_hex32(uint32_t value) {
+    console_write_hex16((value >> 16) & 0xFFFF);
+    console_write_hex16(value & 0xFFFF);
+}
+
+void console_write_hex64(uint64_t value) {
+    console_write_hex32((uint32_t)(value >> 32));
+    console_write_hex32((uint32_t)(value & 0xFFFFFFFF));
+}
+
 void console_init(void) {
     serial_init();
     /* Ensure VGA starts at offset zero to avoid blank screens */

--- a/src/kernel/console/console.h
+++ b/src/kernel/console/console.h
@@ -10,6 +10,8 @@ void console_write(const char *s);
 void console_write_dec(unsigned long value);
 void console_write_hex8(uint8_t value);
 void console_write_hex16(uint16_t value);
+void console_write_hex32(uint32_t value);
+void console_write_hex64(uint64_t value);
 
 /* Poll keyboard driver and queue any typed characters */
 void console_poll_input(void);


### PR DESCRIPTION
## Summary
- map first GiB in bootloader so higher ACPI tables are accessible
- add hex32/hex64 helpers for debug output
- print addresses of discovered ACPI tables
- document new bootloader mapping and debug logging
- plan future checksum validation work

## Testing
- `gcc -I src -DACPI_TEST tests/acpi_test.c src/kernel/acpi/acpi.c -o tests/acpi_test`
- `./tests/acpi_test`
- `gcc -I src -DACPI_TEST tests/acpi_xsdt_test.c src/kernel/acpi/acpi.c -o tests/acpi_xsdt_test`
- `./tests/acpi_xsdt_test`
- `gcc -I src tests/fs_test.c src/kernel/fs/fs.c src/lib/string.c -o tests/fs_test`
- `./tests/fs_test`
- `gcc -I src tests/fs_list_test.c src/kernel/fs/fs.c src/lib/string.c -o tests/fs_list_test`
- `./tests/fs_list_test`
- `gcc -I src tests/fs_delete_test.c src/kernel/fs/fs.c src/lib/string.c -o tests/fs_delete_test`
- `./tests/fs_delete_test`
- `gcc -I src tests/fs_rename_test.c src/kernel/fs/fs.c src/lib/string.c -o tests/fs_rename_test`
- `./tests/fs_rename_test`
- `gcc -I src -DINVENTORY_TEST tests/inventory_test.c src/kernel/inventory/inventory.c src/kernel/inventory/pci_classes.c -o tests/inventory_test`
- `./tests/inventory_test`
- `gcc -I src -DINVENTORY_TEST tests/multi_gpu_inventory_test.c src/kernel/inventory/inventory.c src/kernel/inventory/pci_classes.c -o tests/multi_gpu_inventory_test`
- `./tests/multi_gpu_inventory_test`


------
https://chatgpt.com/codex/tasks/task_e_6849dffc588083209f311f8ebfce07a4