### PR TITLE
Fix truncated kernel load

### DIFF
--- a/Documentation/bootloader/kernel_binary_format.txt
+++ b/Documentation/bootloader/kernel_binary_format.txt
@@ -9,7 +9,7 @@ loaded into memory.
 Requirements for the image:
 
 - Code must be position‑independent within the loaded memory range.
- - The bootloader currently loads 33 sectors (16.5 KiB) starting at the second sector
+ - The bootloader currently loads 34 sectors (17 KiB) starting at the second sector
     of the boot device to address `0x0000:0x1000` (physical `0x1000`).
  - The kernel should not rely on being relocated and must assume long mode is
     already active when control is transferred.

--- a/Documentation/bootloader/loading_routine.txt
+++ b/Documentation/bootloader/loading_routine.txt
@@ -3,12 +3,12 @@ Bootloader Loading Routine
 
 This file describes how the bootloader fetches the kernel from disk. The routine
 assumes the boot device uses BIOS services and that the kernel image occupies the
-33 sectors immediately following the boot sector.
+34 sectors immediately following the boot sector.
 
 1. The boot drive number provided by the BIOS in `DL` is saved so subsequent disk
    reads use the correct device.
 2. A temporary stack is set up at `0x7C00` and data segments are cleared.
-3. Using BIOS interrupt `0x13` with function `0x02`, the loader reads 33 sectors
+3. Using BIOS interrupt `0x13` with function `0x02`, the loader reads 34 sectors
    starting at sector two (CHS `0/0/2`) into memory at address `0x0000:0x1000`.
 4. If the disk read fails, the bootloader hangs to indicate an unrecoverable
    error. Error handling will be refined in later tasks.

--- a/PLAN.md
+++ b/PLAN.md
@@ -23,7 +23,7 @@
 - [ ] Add unit test verifying multiple GPU enumeration
 - [ ] Add unit test for ACPI table lookup
 - [x] Document ACPI table discovery improvements
-- [ ] Investigate boot-time blank screen when ACPI mapping expanded
+- [x] Investigate boot-time blank screen when ACPI mapping expanded
 - [ ] Validate ACPI table checksums for integrity
 - [ ] Map vendor IDs to names in info output
 - [ ] Document dynamic pane manager and key bindings

--- a/src/boot/bootloader.asm
+++ b/src/boot/bootloader.asm
@@ -20,7 +20,7 @@ start:
     mov es, ax
     mov bx, 0x1000
     mov ah, 0x02        ; BIOS read sectors
-    mov al, 33          ; number of sectors to read
+    mov al, 34          ; number of sectors to read
     mov ch, 0
     mov dh, 0
     mov cl, 2           ; start reading after boot sector


### PR DESCRIPTION
## Summary
- load 34 sectors so bootloader reads entire kernel
- document larger sector count in bootloader docs
- mark ACPI blank screen investigation complete

## Testing
- `gcc -std=c99 -Wall -DACPI_TEST -I src tests/acpi_test.c src/kernel/acpi/acpi.c src/lib/string.c -o tests/acpi_test && ./tests/acpi_test`
- `gcc -std=c99 -Wall -DACPI_TEST -I src tests/acpi_xsdt_test.c src/kernel/acpi/acpi.c src/lib/string.c -o tests/acpi_xsdt_test && ./tests/acpi_xsdt_test`
- `gcc -std=c99 -Wall -I src tests/fs_list_test.c src/lib/string.c src/kernel/fs/fs.c -o tests/fs_list_test && ./tests/fs_list_test`
- `gcc -std=c99 -Wall -I src tests/fs_rename_test.c src/lib/string.c src/kernel/fs/fs.c -o tests/fs_rename_test && ./tests/fs_rename_test`
- `gcc -std=c99 -Wall -I src tests/fs_delete_test.c src/lib/string.c src/kernel/fs/fs.c -o tests/fs_delete_test && ./tests/fs_delete_test`
- `gcc -std=c99 -Wall -I src tests/inventory_test.c src/lib/string.c src/kernel/inventory/inventory.c src/kernel/inventory/pci_classes.c -o tests/inventory_test && ./tests/inventory_test` *(fails: Segmentation fault)*
- `gcc -std=c99 -Wall -I src tests/multi_gpu_inventory_test.c src/lib/string.c src/kernel/inventory/inventory.c src/kernel/inventory/pci_classes.c -o tests/multi_gpu_inventory_test && ./tests/multi_gpu_inventory_test` *(fails: Segmentation fault)*
- `bash scripts/build_image.sh`


------
https://chatgpt.com/codex/tasks/task_e_6849f0814ca0832085999b1d8cfe9db1