### PR TITLE
Fix ACPI table lookup with 2GiB mapping

### DIFF
--- a/Documentation/bootloader/kernel_binary_format.txt
+++ b/Documentation/bootloader/kernel_binary_format.txt
@@ -9,7 +9,7 @@ loaded into memory.
 Requirements for the image:
 
 - Code must be position‑independent within the loaded memory range.
- - The bootloader currently loads 33 sectors (16.5 KiB) starting at the second sector
+ - The bootloader currently loads 34 sectors (17 KiB) starting at the second sector
     of the boot device to address `0x0000:0x1000` (physical `0x1000`).
  - The kernel should not rely on being relocated and must assume long mode is
     already active when control is transferred.

--- a/Documentation/bootloader/loading_routine.txt
+++ b/Documentation/bootloader/loading_routine.txt
@@ -3,12 +3,12 @@ Bootloader Loading Routine
 
 This file describes how the bootloader fetches the kernel from disk. The routine
 assumes the boot device uses BIOS services and that the kernel image occupies the
-33 sectors immediately following the boot sector.
+34 sectors immediately following the boot sector.
 
 1. The boot drive number provided by the BIOS in `DL` is saved so subsequent disk
    reads use the correct device.
 2. A temporary stack is set up at `0x7C00` and data segments are cleared.
-3. Using BIOS interrupt `0x13` with function `0x02`, the loader reads 33 sectors
+3. Using BIOS interrupt `0x13` with function `0x02`, the loader reads 34 sectors
    starting at sector two (CHS `0/0/2`) into memory at address `0x0000:0x1000`.
 4. If the disk read fails, the bootloader hangs to indicate an unrecoverable
    error. Error handling will be refined in later tasks.

--- a/PLAN.md
+++ b/PLAN.md
@@ -23,7 +23,9 @@
 - [ ] Add unit test verifying multiple GPU enumeration
 - [ ] Add unit test for ACPI table lookup
 - [x] Document ACPI table discovery improvements
-- [ ] Investigate boot-time blank screen when ACPI mapping expanded
+- [x] Investigate boot-time blank screen when ACPI mapping expanded
+- [x] Expand bootloader identity mapping to 2 GiB
+- [x] Update ACPI parser to accept tables below 2 GiB
 - [ ] Validate ACPI table checksums for integrity
 - [ ] Map vendor IDs to names in info output
 - [ ] Document dynamic pane manager and key bindings

--- a/src/boot/bootloader.asm
+++ b/src/boot/bootloader.asm
@@ -20,7 +20,7 @@ start:
     mov es, ax
     mov bx, 0x1000
     mov ah, 0x02        ; BIOS read sectors
-    mov al, 33          ; number of sectors to read
+    mov al, 34          ; number of sectors to read
     mov ch, 0
     mov dh, 0
     mov cl, 2           ; start reading after boot sector
@@ -45,7 +45,7 @@ protected_mode:
     mov ss, ax
     mov esp, 0x7C00
 
-    ; Build identity mapped paging structures for first 1 GiB
+    ; Build identity mapped paging structures for first 2 GiB
     mov eax, pdpt
     or eax, 0x03
     mov [pml4], eax
@@ -54,6 +54,10 @@ protected_mode:
     or eax, 0x03
     mov [pdpt], eax
     mov dword [pdpt+4], 0
+    mov eax, pd2
+    or eax, 0x03
+    mov [pdpt+8], eax
+    mov dword [pdpt+12], 0
     xor ecx, ecx
 setup_pd:
     mov eax, ecx
@@ -64,6 +68,18 @@ setup_pd:
     inc ecx
     cmp ecx, 512
     jne setup_pd
+
+    xor ecx, ecx
+setup_pd2:
+    mov eax, ecx
+    shl eax, 21
+    add eax, 0x40000000        ; 1 GiB offset
+    or eax, 0x83
+    mov [pd2 + ecx*8], eax
+    mov dword [pd2 + ecx*8 + 4], 0
+    inc ecx
+    cmp ecx, 512
+    jne setup_pd2
 
     ; Load paging structures
     mov eax, pml4
@@ -176,6 +192,7 @@ DATA64_SEL equ 0x20
 pml4   equ 0x8000
 pdpt   equ 0x9000
 pd     equ 0xA000
+pd2    equ 0xB000
 
 times 510-($-$$) db 0
 dw 0xAA55

--- a/src/kernel/acpi/acpi.c
+++ b/src/kernel/acpi/acpi.c
@@ -99,14 +99,14 @@ void acpi_init(void) {
             sdt = (struct acpi_sdt_header *)(start + rsdp->rsdt_address);
 #else
         /*
-         * The bootloader identity maps the first gigabyte so tables can
+ * The bootloader identity maps the first two gigabytes so tables can
          * reside above the traditional 1 MiB boundary.  Accept any address
-         * below 0x40000000 which keeps the parser simple while covering the
+ * below 0x80000000 which keeps the parser simple while covering the
          * mapped region.
          */
-        if (use_xsdt && rsdp->xsdt_address < 0x40000000)
+        if (use_xsdt && rsdp->xsdt_address < 0x80000000)
             sdt = (struct acpi_sdt_header *)(uintptr_t)rsdp->xsdt_address;
-        else if (!use_xsdt && rsdp->rsdt_address < 0x40000000)
+        else if (!use_xsdt && rsdp->rsdt_address < 0x80000000)
             sdt = (struct acpi_sdt_header *)(uintptr_t)rsdp->rsdt_address;
 #endif
         if (sdt) {
@@ -131,8 +131,8 @@ void acpi_init(void) {
 #ifdef ACPI_TEST
                 hdr = (struct acpi_sdt_header *)(start + addr);
 #else
-                /* Allow tables anywhere within the 1 GiB region mapped by the bootloader */
-                hdr = (addr < 0x40000000) ? (struct acpi_sdt_header *)addr : NULL;
+                /* Allow tables anywhere within the 2 GiB region mapped by the bootloader */
+                hdr = (addr < 0x80000000) ? (struct acpi_sdt_header *)addr : NULL;
 #endif
                 if (!hdr)
                     continue;


### PR DESCRIPTION
## Summary
- expand bootloader paging setup to map first 2GiB
- allow ACPI parser to accept tables below 2GiB
- mark mapping changes as complete in PLAN

## Testing
- `gcc -std=c99 -Wall -DACPI_TEST -I src tests/acpi_test.c src/kernel/acpi/acpi.c src/lib/string.c -o tests/acpi_test && ./tests/acpi_test`
- `gcc -std=c99 -Wall -DACPI_TEST -I src tests/acpi_xsdt_test.c src/kernel/acpi/acpi.c src/lib/string.c -o tests/acpi_xsdt_test && ./tests/acpi_xsdt_test`
- `gcc -std=c99 -Wall -I src tests/fs_list_test.c src/lib/string.c src/kernel/fs/fs.c -o tests/fs_list_test && ./tests/fs_list_test`
- `gcc -std=c99 -Wall -I src tests/inventory_test.c src/lib/string.c src/kernel/inventory/inventory.c src/kernel/inventory/pci_classes.c -o tests/inventory_test && ./tests/inventory_test` *(fails: Segmentation fault)*
- `gcc -std=c99 -Wall -I src tests/multi_gpu_inventory_test.c src/lib/string.c src/kernel/inventory/inventory.c src/kernel/inventory/pci_classes.c -o tests/multi_gpu_inventory_test && ./tests/multi_gpu_inventory_test` *(fails: Segmentation fault)*
- `bash scripts/build_image.sh`


------
https://chatgpt.com/codex/tasks/task_e_6849f0814ca0832085999b1d8cfe9db1