### PR TITLE
Fix console backspace handling

### DIFF
--- a/Documentation/architecture/kernel/console/input_handling.txt
+++ b/Documentation/architecture/kernel/console/input_handling.txt
@@ -4,10 +4,10 @@ character is available it is stored in the buffer provided space remains.
 
 Kernel components can retrieve typed characters using `console_getc()`. The
 function returns `0` when the buffer is empty. Basic line editing is provided:
-pressing backspace removes the most recently queued character. The left and
-right arrow keys move the cursor within the current line so characters can be
-inserted or removed at any position. More advanced editing will be handled by
-higher layers.
+pressing backspace adds a control character to the buffer which higher layers
+interpret to delete the preceding character. The left and right arrow keys move
+the cursor within the current line so characters can be inserted or removed at
+any position. More advanced editing will be handled by higher layers.
 
 The kernel's idle task calls `console_poll_input()` on every loop
 iteration to ensure keystrokes are collected even when no other tasks

--- a/PLAN.md
+++ b/PLAN.md
@@ -26,4 +26,5 @@
 - [ ] Remove demo task output loop
 - [ ] Persist command input when panes are redrawn
 - [ ] Add unit test for shell history navigation
+- [ ] Add unit test for backspace character handling in console input
 - [ ] Add unit test verifying console text persists after initialization

--- a/src/kernel/console/console.c
+++ b/src/kernel/console/console.c
@@ -180,19 +180,13 @@ void console_poll_input(void) {
         break;
     }
 
-    if (c == '\b') {
-        if (input_head != input_tail) {
-            if (input_head == 0)
-                input_head = INPUT_BUF_SIZE - 1;
-            else
-                input_head--;
-        }
-    } else {
-        unsigned int next_head = (input_head + 1) % INPUT_BUF_SIZE;
-        if (next_head != input_tail) {
-            input_buf[input_head] = c;
-            input_head = next_head;
-        }
+    if (c == '\b' || c == 0x7F)
+        c = '\b';
+
+    unsigned int next_head = (input_head + 1) % INPUT_BUF_SIZE;
+    if (next_head != input_tail) {
+        input_buf[input_head] = c;
+        input_head = next_head;
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure backspace presses are queued instead of removing from the input buffer
- interpret DEL key as backspace
- document new input handling behavior
- plan unit test for backspace handling

## Testing
- `gcc -I src -DINVENTORY_TEST tests/inventory_test.c src/kernel/inventory/inventory.c src/kernel/inventory/pci_classes.c -o tests/inventory_test && ./tests/inventory_test`
- `gcc -I src -DINVENTORY_TEST tests/multi_gpu_inventory_test.c src/kernel/inventory/inventory.c src/kernel/inventory/pci_classes.c -o tests/multi_gpu_inventory_test && ./tests/multi_gpu_inventory_test`
- `gcc -I src tests/fs_test.c src/kernel/fs/fs.c src/lib/string.c -o tests/fs_test && ./tests/fs_test`
- `gcc -I src tests/fs_list_test.c src/kernel/fs/fs.c src/lib/string.c -o tests/fs_list_test && ./tests/fs_list_test`
- `gcc -I src tests/fs_delete_test.c src/kernel/fs/fs.c src/lib/string.c -o tests/fs_delete_test && ./tests/fs_delete_test`
- `gcc -I src tests/fs_rename_test.c src/kernel/fs/fs.c src/lib/string.c -o tests/fs_rename_test && ./tests/fs_rename_test`
- `gcc -I src -DACPI_TEST tests/acpi_test.c src/kernel/acpi/acpi.c -o tests/acpi_test && ./tests/acpi_test`
- `gcc -I src -DACPI_TEST tests/acpi_xsdt_test.c src/kernel/acpi/acpi.c -o tests/acpi_xsdt_test && ./tests/acpi_xsdt_test`

------
https://chatgpt.com/codex/tasks/task_e_6849f778ef508320b95e8f9321309d2b